### PR TITLE
Bootstrap PYTHONPATH

### DIFF
--- a/rpm/template.spec.em
+++ b/rpm/template.spec.em
@@ -31,6 +31,9 @@ Source0:        %{name}-%{version}.tar.gz
 %autosetup
 
 %build
+# Needed to bootstrap since the ros_workspace package does not yet exist.
+export PYTHONPATH=@(InstallationPrefix)/lib/python%{python3_version}/site-packages
+
 # In case we're installing to a non-standard location, look for a setup.sh
 # in the install tree and source it.  It will set things like
 # CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
@@ -51,6 +54,9 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
 %make_build
 
 %install
+# Needed to bootstrap since the ros_workspace package does not yet exist.
+export PYTHONPATH=@(InstallationPrefix)/lib/python%{python3_version}/site-packages
+
 # In case we're installing to a non-standard location, look for a setup.sh
 # in the install tree and source it.  It will set things like
 # CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
@@ -59,6 +65,9 @@ if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.
 
 %if 0%{?with_tests}
 %check
+# Needed to bootstrap since the ros_workspace package does not yet exist.
+export PYTHONPATH=@(InstallationPrefix)/lib/python%{python3_version}/site-packages
+
 # Look for a Makefile target with a name indicating that it runs tests
 TEST_TARGET=$(%__make -qp -C obj-%{_target_platform} | sed "s/^\(test\|check\):.*/\\1/;t f;d;:f;q0")
 if [ -n "$TEST_TARGET" ]; then


### PR DESCRIPTION
Debian counterpart: https://github.com/ros2-gbp/ament_cmake-release/blob/patches/debian/eloquent/ament_cmake_core/0001-Manually-add-custom-PYTHONPATH.patch

**NOTE**: If this PR is squash-merged, be sure to drop the PR number from the end of the commit message, or every time this patch is re-applied by Bloom, it will be back-linked from this PR.