### PR TITLE
Fix release_tag field in active distributions.

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -144,7 +144,7 @@ tracks:
     patches: null
     release_inc: '1'
     release_repo_url: null
-    release_tag: foxy
+    release_tag: :{version}
     ros_distro: foxy
     vcs_type: git
     vcs_uri: https://github.com/ament/ament_cmake.git
@@ -246,7 +246,7 @@ tracks:
     patches: null
     release_inc: '1'
     release_repo_url: null
-    release_tag: master
+    release_tag: :{version}
     ros_distro: rolling
     vcs_type: git
     vcs_uri: https://github.com/ament/ament_cmake.git


### PR DESCRIPTION
To be honest, I'm not sure how this configuration value has been working, I suppose that releases have generally gotten lucky in that the contents of the tag and the contents of the branch set in release_tag have been synonymous but the correct config value for this in ROS 2 repositories is the `:{version}` substitution.

 Together with `version: :{auto}` and a proper devel_branch will find the version at the head of the devel_branch and use the version value as the release tag.

This should resolve challenges with future ament_cmake releases in all active ROS 2 distros and is a good thing to fix before the Jammy transition.