### PR TITLE
Restore PYTHONPATH bootstrap patch to ament_cmake_core.

### DIFF
--- a/rpm/template.spec.em
+++ b/rpm/template.spec.em
@@ -31,6 +31,9 @@ Source0:        %{name}-%{version}.tar.gz
 %autosetup -p1
 
 %build
+# Needed to bootstrap since the ros_workspace package does not yet exist.
+export PYTHONPATH=@(InstallationPrefix)/lib/python%{python3_version}/site-packages
+
 # In case we're installing to a non-standard location, look for a setup.sh
 # in the install tree and source it.  It will set things like
 # CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
@@ -51,6 +54,9 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
 %make_build
 
 %install
+# Needed to bootstrap since the ros_workspace package does not yet exist.
+export PYTHONPATH=@(InstallationPrefix)/lib/python%{python3_version}/site-packages
+
 # In case we're installing to a non-standard location, look for a setup.sh
 # in the install tree and source it.  It will set things like
 # CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
@@ -59,6 +65,9 @@ if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.
 
 %if 0%{?with_tests}
 %check
+# Needed to bootstrap since the ros_workspace package does not yet exist.
+export PYTHONPATH=@(InstallationPrefix)/lib/python%{python3_version}/site-packages
+
 # Look for a Makefile target with a name indicating that it runs tests
 TEST_TARGET=$(%__make -qp -C obj-%{_target_platform} | sed "s/^\(test\|check\):.*/\\1/;t f;d;:f;q0")
 if [ -n "$TEST_TARGET" ]; then


### PR DESCRIPTION
This patch was previously applied to the rpm spec template for this package to facilitate finding the ROS installation prefix's python libraries without the ros_bootstrap package since this is a required dependency of ros_bootstrap.

The rosdistro migration tools[1] ought to have preserved these patches however I suspect that behavior is not working correctly when the source and destination distribution are the same.

[1]: https://github.com/ros/rosdistro/tree/master/migration-tools