### PR TITLE
Restore PYTHONPATH bootstrap patch to ament_cmake_core. 

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -18,6 +18,9 @@ export PKG_CONFIG_PATH=@(InstallationPrefix)/lib/pkgconfig
 # 	https://github.com/ros-infrastructure/bloom/issues/327
 export DEB_CXXFLAGS_MAINT_APPEND=-DNDEBUG
 
+# Needed to bootstrap since the ros_workspace package does not yet exist.
+export PYTHONPATH=@(InstallationPrefix)/lib/python3.9/site-packages:@(InstallationPrefix)/lib/python3.8/site-packages:@(InstallationPrefix)/lib/python3.7/site-packages
+
 %:
 	dh $@@ -v --buildsystem=cmake
 


### PR DESCRIPTION
This patch was previously applied to the debian templates for this package to facilitate finding the ROS installation prefix's python libraries without the ros_bootstrap package since this is a required dependency of ros_bootstrap.

The rosdistro migration tools[1] ought to have preserved these patches however I suspect that behavior is not working correctly when the source and destination distribution are the same.

[1]: https://github.com/ros/rosdistro/tree/master/migration-tools