### PR TITLE
Update rolling devel_branch to match rosdistro source entry

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -266,7 +266,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: master
+    devel_branch: rolling
     last_release: master
     last_version: 1.4.0
     name: ament_cmake


### PR DESCRIPTION
This PR from an automated script updates the devel_branch for rolling to match the source branch as specified in https://github.com/ros/rosdistro/rolling/distribution.yaml .
