### PR TITLE
Detect Python 3 version at build time

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -24,7 +24,8 @@ endif
 DEB_HOST_GNU_TYPE ?= $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
 
 # Needed to bootstrap since the ros_workspace package does not yet exist.
-export PYTHONPATH=@(InstallationPrefix)/lib/python3.12/site-packages
+PYTHON3_VERSION=$(shell py3versions -d)
+export PYTHONPATH=@(InstallationPrefix)/lib/$(PYTHON3_VERSION)/site-packages
 
 %:
 	dh $@@ -v --buildsystem=cmake --builddirectory=.obj-$(DEB_HOST_GNU_TYPE)


### PR DESCRIPTION
1. We'll no longer need to update this patch when we stand up new platforms
2. The patch will be compatible with more than one platform at a time

(credits to @j-rivero for suggesting this approach :clap:)

When this change is approved, I'll take care of merging it and exporting it with Bloom. I'll also apply it to other tracks, as they all suffer from this issue.